### PR TITLE
Update dependencies and code style check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
     "npm-asset/chartist-plugin-tooltips": "^0.0.18"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
     "matthiasmullie/minify": "^1.3",
-    "slowprog/composer-copy-file": "^0.2",
-    "squizlabs/php_codesniffer": "^3.1",
-    "wimg/php-compatibility": "^8.0",
-    "wp-coding-standards/wpcs": "^0.14"
+    "phpcompatibility/php-compatibility": "^9.1",
+    "slowprog/composer-copy-file": "^0.3",
+    "squizlabs/php_codesniffer": "^3.4",
+    "wp-coding-standards/wpcs": "^1.2"
   },
   "repositories": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55d9ee0785e909c4c83c7575c760f481",
+    "content-hash": "863ef7bb0dc20a70c44cec74362b28a7",
     "packages": [
         {
             "name": "npm-asset/chartist",
@@ -43,29 +43,27 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.4.4",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
                 "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "*"
+                "squizlabs/php_codesniffer": "^2|^3"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "wimg/php-compatibility": "^8.0"
-            },
-            "suggest": {
-                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -83,13 +81,13 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "f.nijhof@dealerdirect.nl",
-                    "homepage": "http://workingatdealerdirect.eu",
-                    "role": "Developer"
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://workingatdealerdirect.eu",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -107,7 +105,7 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "time": "2018-10-26T13:21:45+00:00"
         },
         {
             "name": "matthiasmullie/minify",
@@ -219,26 +217,85 @@
             "time": "2018-10-25T15:19:41+00:00"
         },
         {
-            "name": "slowprog/composer-copy-file",
-            "version": "0.2.1",
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/slowprog/CopyFile.git",
-                "reference": "400c2b7c9f9f8ed8195217ae143ffbf3fec84c31"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "a898db5410e365eeb658c63a76bd08d211769321"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slowprog/CopyFile/zipball/400c2b7c9f9f8ed8195217ae143ffbf3fec84c31",
-                "reference": "400c2b7c9f9f8ed8195217ae143ffbf3fec84c31",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/a898db5410e365eeb658c63a76bd08d211769321",
+                "reference": "a898db5410e365eeb658c63a76bd08d211769321",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                },
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-12-16T19:16:39+00:00"
+        },
+        {
+            "name": "slowprog/composer-copy-file",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slowprog/CopyFile.git",
+                "reference": "4cc40170fb369f6ab2082fb06ce3685dc12ea496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slowprog/CopyFile/zipball/4cc40170fb369f6ab2082fb06ce3685dc12ea496",
+                "reference": "4cc40170fb369f6ab2082fb06ce3685dc12ea496",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
             },
             "require-dev": {
                 "composer/composer": "1.0.*@dev",
                 "mikey179/vfsstream": "~1",
-                "phpunit/phpunit": "~5.0",
+                "php-mock/php-mock-phpunit": "~1",
+                "phpunit/phpunit": "5.7.27",
                 "symfony/filesystem": "~2.7",
                 "symfony/finder": "~2.7"
             },
@@ -263,7 +320,7 @@
             "keywords": [
                 "copy file"
             ],
-            "time": "2017-12-07T13:18:47+00:00"
+            "time": "2018-12-26T14:01:51+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -317,79 +374,28 @@
             "time": "2018-12-19T23:57:18+00:00"
         },
         {
-            "name": "wimg/php-compatibility",
-            "version": "8.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                }
-            ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "abandoned": "phpcompatibility/php-compatibility",
-            "time": "2018-07-17T13:42:26+00:00"
-        },
-        {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.1",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -408,7 +414,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2018-12-18T09:43:51+00:00"
         }
     ],
     "aliases": [],

--- a/extended-evaluation-for-statify.php
+++ b/extended-evaluation-for-statify.php
@@ -16,6 +16,8 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
+define( 'EEFSTATFIFY_VERSION', '2.5.0' );
+
 // Includes.
 require_once 'inc/queries.php';
 require_once 'inc/formatting.php';
@@ -138,7 +140,9 @@ function eefstatify_enqueue_style( $style_name, $style_path ) {
 		plugins_url(
 			$style_path,
 			__FILE__
-		)
+		),
+		[],
+		EEFSTATFIFY_VERSION
 	);
 }
 
@@ -149,14 +153,15 @@ function eefstatify_enqueue_style( $style_name, $style_path ) {
  * @param string $script_path the plugin-relative path of the JavaScript.
  * @param array  $dependencies the dependencies.
  */
-function eefstatify_enqueue_script( $script_name, $script_path, $dependencies = array() ) {
+function eefstatify_enqueue_script( $script_name, $script_path, $dependencies = [] ) {
 	wp_enqueue_script(
 		$script_name,
 		plugins_url(
 			$script_path,
 			__FILE__
 		),
-		$dependencies
+		$dependencies,
+		EEFSTATFIFY_VERSION
 	);
 }
 
@@ -164,7 +169,7 @@ function eefstatify_enqueue_script( $script_name, $script_path, $dependencies = 
  * Create an item and submenu items in the WordPress admin menu.
  */
 function eefstatify_add_menu() {
-	$page_hook_suffixes = array();
+	$page_hook_suffixes = [];
 	$page_hook_suffixes[] = add_menu_page(
 		__( 'Statify – Extended Evaluation', 'extended-evaluation-for-statify' ), // page title.
 		'Statify', // title in the menu.

--- a/inc/queries.php
+++ b/inc/queries.php
@@ -51,7 +51,7 @@ function eefstatify_get_years() {
 		ORDER BY `year` DESC",
 		ARRAY_A
 	);
-	$years = array();
+	$years = [];
 	foreach ( $results as $result ) {
 		array_push( $years, intval( $result['year'] ) );
 	}
@@ -90,7 +90,7 @@ function eefstatify_get_views_for_all_days( $post_url = '' ) {
 			ARRAY_A
 		);
 	}
-	$views_for_all_days = array();
+	$views_for_all_days = [];
 	foreach ( $results as $result ) {
 		$views_for_all_days[ $result['date'] ] = $result['count'];
 	}
@@ -156,7 +156,7 @@ function eefstatify_get_views_for_all_months( $post_url = '' ) {
 			ARRAY_A
 		);
 	}
-	$views_for_all_months = array();
+	$views_for_all_months = [];
 	foreach ( $results as $result ) {
 		$views_for_all_months[ $result['date'] ] = $result['count'];
 	}
@@ -206,7 +206,7 @@ function eefstatify_get_average_daily_views_of_month( $views_for_all_months, $ye
  */
 function eefstatify_get_daily_views_of_month( $views_for_all_days, $year, $month ) {
 	$days = eefstatify_get_days( $month, $year );
-	$views = array();
+	$views = [];
 	foreach ( $days as $day ) {
 		array_push( $views, intval( eefstatify_get_daily_views( $views_for_all_days, $year, $month, $day ) ) );
 	}
@@ -244,7 +244,7 @@ function eefstatify_get_views_for_all_years( $post_url = '' ) {
 			ARRAY_A
 		);
 	}
-	$views_for_all_years = array();
+	$views_for_all_years = [];
 	foreach ( $results as $result ) {
 		$views_for_all_years[ $result['date'] ] = $result['count'];
 	}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -38,6 +38,10 @@
     <rule ref="WordPress.VIP.DirectDatabaseQuery.NoCaching">
         <exclude-pattern>queries.php</exclude-pattern>
     </rule>
+    <rule ref="WordPress.WP.GlobalVariablesOverride.OverrideProhibited">
+        <exclude-pattern>content.php</exclude-pattern>
+        <exclude-pattern>dashboard.php</exclude-pattern>
+    </rule>
     <rule ref="WordPress.WP.I18n">
         <properties>
             <property name="text_domain" type="array" value="extended-evaluation-for-statify" />
@@ -45,6 +49,6 @@
     </rule>
 
     <!-- Include sniffs for PHP cross-version compatibility. -->
-    <config name="testVersion" value="5.6-"/>
+    <config name="testVersion" value="5.4-"/>
     <rule ref="PHPCompatibility"/>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: patrickrobrecht
 Tags: stats, analytics, privacy, statistics
 Requires at least: 4.4
 Tested up to: 5.0
-Requires PHP: 5.6
+Requires PHP: 5.4
 Stable tag: 2.5-dev
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/views/dashboard.php
+++ b/views/dashboard.php
@@ -225,7 +225,7 @@ if ( 0 === $selected_year ) {
 				<tr>
 					<td><?php esc_html_e( 'Minimum', 'extended-evaluation-for-statify' ); ?></td>
 					<?php
-					$daily_views = array();
+					$daily_views = [];
 					foreach ( $months as $month ) {
 						$daily_views[ $month ] = eefstatify_get_daily_views_of_month( $views_for_all_days, $selected_year, $month );
 						?>


### PR DESCRIPTION
- Update dependencies.
- Make compatible to latest version of WordPress coding guidelines.
- Declare backwards compatibility with PHP 5.4+.