### PR TITLE
Add selected date range to the subtitle in most popular posts diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 2.x
 
+### Version 2.6.3
+* Bugfix: Index and post title tooltip in most popular posts diagram (introduced with bugfix version 2.6.2)
+* Bugfix: Add selected date range to the subtitle in most popular posts diagram
+
 ### Version 2.6.2
 * Bugfix: Error in most popular posts diagram showing multiple pages with the same title
 

--- a/views/content.php
+++ b/views/content.php
@@ -89,7 +89,7 @@ if ( 'popular' === $selected_post_type ) {
 		eefstatify_echo_chart_container(
 			'chart-popular-content',
 			__( 'Most Popular Content', 'extended-evaluation-for-statify' ),
-			'',
+			eefstatify_get_date_period_string( $start, $end, $valid_start && $valid_end, true ),
 			$legend
 		);
 		?>


### PR DESCRIPTION
The subtitle of the most popular posts diagram did not contain the date range if a filter for the time period is active. This  PR makes the behavior consistent with the referrer view.