### PR TITLE
Fix CSV injection, release 2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+## Version 2.6.4
+
 ### Changed
 - Updated dependencies, including the Chartist library used for the charts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated dependencies, including the Chartist library used for the charts
 
+### Security
+- Precede cell values starting with = or another spreadsheet meta-character with a single quote to avoid CSV injection
+
 
 ## Version 2.x
 

--- a/extended-evaluation-for-statify.php
+++ b/extended-evaluation-for-statify.php
@@ -3,7 +3,7 @@
  * Plugin Name: Statify – Extended Evaluation
  * Plugin URI: https://patrick-robrecht.de/wordpress/
  * Description: Extended evaluation for the compact, easy-to-use and privacy-compliant Statify plugin.
- * Version: 2.6.3
+ * Version: 2.6.4
  * Author: Patrick Robrecht
  * Author URI: https://patrick-robrecht.de/
  * License: GPLv3
@@ -16,7 +16,7 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-define( 'EEFSTATFIFY_VERSION', '2.6.3' );
+define( 'EEFSTATFIFY_VERSION', '2.6.4' );
 
 // Includes.
 require_once 'inc/queries.php';

--- a/js/functions.js
+++ b/js/functions.js
@@ -5,6 +5,7 @@ function eefstatifyTableToCsv(table, filename) {
 		// Actual delimiters for CSV.
 		colDelim = '","',
 		rowDelim = '"\r\n"',
+		forbiddenStartCharacters = ['+', '-', '=', '@'],
 		rows = table.find('tr'),
 		csv =
 			'"' +
@@ -13,7 +14,19 @@ function eefstatifyTableToCsv(table, filename) {
 					return jQuery(row)
 						.find('td,th')
 						.map(function (j, col) {
-							return jQuery(col).text().replace(/"/g, '""'); // escape double quotes
+							let text = jQuery(col).text();
+							// Escape double quotes and trim result.
+							text = text.replace(/"/g, '""').trim();
+							// Precede cell values starting with = or another spreadsheet meta-character with a single quote to avoid CSV injection.
+							const startCharacter = text.substring(0, 1);
+							if (
+								forbiddenStartCharacters.includes(
+									startCharacter
+								)
+							) {
+								text = "'" + text;
+							}
+							return text;
 						})
 						.get()
 						.join(tmpColDelim);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: stats, analytics, privacy, statistics
 Requires at least: 4.4
 Tested up to: 6.3
 Requires PHP: 5.4
-Stable tag: 2.6.3
+Stable tag: 2.6.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -60,6 +60,10 @@ Therefore you'll have to add the *see_statify_evaluation* capability to the user
 
 Please see [the changelog at GitHub](https://github.com/patrickrobrecht/extended-evaluation-for-statify/blob/master/CHANGELOG.md) for the details.
 
+= 2.6.4 =
+- Bugfix: Updated dependencies, including the Chartist library used for the charts
+- Security fix: Precede cell values starting with = or another spreadsheet meta-character with a single quote to avoid CSV injection
+
 = 2.6.3 =
 * Bugfix: Index and post title tooltip in most popular posts diagram (introduced with bugfix version 2.6.2)
 * Bugfix: Add selected date range to the subtitle in most popular posts diagram
@@ -84,5 +88,5 @@ Please see [the changelog at GitHub](https://github.com/patrickrobrecht/extended
 
 == Upgrade Notice ==
 
-= 2.6.3 =
-This release fixes bugs in the most popular posts diagram.
+= 2.6.4 =
+This release contains a security fix and all users are encouraged to update to this version.


### PR DESCRIPTION
Fix https://github.com/patrickrobrecht/extended-evaluation-for-statify/security/advisories/GHSA-rpcj-gfwj-2r7w to avoid formulas in CSV file which could be included due to a post title containing something like `@SUM(1+1)*cmd|' /C calc'!A0 `.